### PR TITLE
refactor group logic

### DIFF
--- a/package/api/src/controllers/v1/auth/login/mod.rs
+++ b/package/api/src/controllers/v1/auth/login/mod.rs
@@ -116,6 +116,7 @@ impl LoginControllerV1 {
                 name: None,
                 group: None,
                 role: None,
+                email: body.email.clone(),
             },
             id.clone(),
         )

--- a/package/api/src/controllers/v1/auth/login/mod.rs
+++ b/package/api/src/controllers/v1/auth/login/mod.rs
@@ -85,6 +85,7 @@ impl LoginControllerV1 {
             .map_err(|e| ApiError::ValidationError(e.to_string()))?)
     }
 
+    // FIXME: deprecated
     async fn create_member(body: LoginParams) -> Result<(), ApiError> {
         let log = root();
         let cli = easy_dynamodb::get_client(&log);
@@ -110,12 +111,13 @@ impl LoginControllerV1 {
 
         let member: Member = (
             CreateMemberRequest {
-                email: body.email.clone(),
+                user_id: id.clone(),
+                org_id: "default".to_string(),
                 name: None,
                 group: None,
                 role: None,
             },
-            id,
+            id.clone(),
         )
             .into();
 

--- a/package/api/src/controllers/v1/auth/signup/mod.rs
+++ b/package/api/src/controllers/v1/auth/signup/mod.rs
@@ -1,16 +1,12 @@
 use by_axum::axum::routing::post;
 use by_axum::axum::{Json, Router};
 use by_axum::{axum::extract::State, log::root};
-use models::prelude::{Organization, OrganizationMember};
-use models::{
-    prelude::{CreateMemberRequest, Member},
-    User,
-};
+use models::prelude::{Organization, OrganizationMember, Role};
+use models::User;
 use serde::Deserialize;
 use slog::o;
 
 use super::super::verification::email::{verify_handler, EmailVerifyParams};
-use crate::common::CommonQueryResponse;
 use crate::utils::{error::ApiError, hash::get_hash_string};
 
 #[derive(Deserialize, Clone, Debug)]
@@ -85,18 +81,18 @@ impl SignupControllerV1 {
             .await
             .map_err(|e| ApiError::DynamoCreateException(e.to_string()))?;
 
-        let _ = SignupControllerV1::create_organization(user.id.clone(), body.clone()).await?;
+        let org_id = SignupControllerV1::create_organization(user.id.clone(), body.clone()).await?;
 
-        let _ = SignupControllerV1::create_member(body).await?; //FIXME: add to organization
+        let _ = SignupControllerV1::create_member(org_id, user.id).await?; //FIXME: add to organization
 
         Ok(())
     }
 
-    async fn create_organization(user_id: String, body: SignUpParams) -> Result<(), ApiError> {
+    async fn create_organization(user_id: String, body: SignUpParams) -> Result<String, ApiError> {
         let log = root();
         let cli = easy_dynamodb::get_client(&log);
 
-        let id = uuid::Uuid::new_v4().to_string();
+        let id: String = uuid::Uuid::new_v4().to_string();
 
         let organization: Organization =
             Organization::new(id.clone(), user_id.clone(), body.email.clone());
@@ -105,55 +101,26 @@ impl SignupControllerV1 {
             .await
             .map_err(|e| ApiError::DynamoCreateException(e.to_string()))?;
 
-        let organization_member_id = uuid::Uuid::new_v4().to_string();
-        let organization_member: OrganizationMember =
-            OrganizationMember::new(organization_member_id, user_id.clone(), id.clone());
-        let _ = cli
-            .upsert(organization_member)
-            .await
-            .map_err(|e| ApiError::DynamoCreateException(e.to_string()))?;
-
-        Ok(())
+        Ok(id)
     }
 
-    async fn create_member(body: SignUpParams) -> Result<(), ApiError> {
+    async fn create_member(org_id:String, user_id: String) -> Result<(), ApiError> {
         let log = root();
         let cli = easy_dynamodb::get_client(&log);
 
-        let res: CommonQueryResponse<Member> = CommonQueryResponse::query(
-            &log,
-            "gsi1-index",
-            None,
-            Some(1),
-            vec![("gsi1", Member::get_gsi1(body.email.clone()))],
-        )
-        .await?;
+        let organization_member_id = uuid::Uuid::new_v4().to_string();
+        let organization_member: OrganizationMember =
+            OrganizationMember::new(organization_member_id, user_id.clone(), org_id.clone(), Some(Role::Admin));
+        let _ = cli
+            .upsert(organization_member.clone())
+            .await
+            .map_err(|e| ApiError::DynamoCreateException(e.to_string()))?;
 
-        if res.items.len() != 0 {
-            let item = res.items.first().unwrap();
 
-            if item.deleted_at.is_none() {
-                return Ok(()); //already invited member
-            }
-        }
-
-        let id = uuid::Uuid::new_v4().to_string();
-
-        let member: Member = (
-            CreateMemberRequest {
-                email: body.email.clone(),
-                name: None,
-                group: None,
-                role: None,
-            },
-            id,
-        )
-            .into();
-
-        match cli.upsert(member).await {
+        match cli.upsert(organization_member.clone()).await {
             Ok(()) => Ok(()),
             Err(e) => {
-                slog::error!(log, "Create Member Failed {e:?}");
+                slog::error!(log, "Create Organization Member Failed {e:?}");
                 Err(ApiError::DynamoCreateException(e.to_string()))
             }
         }

--- a/package/api/src/controllers/v1/groups/mod.rs
+++ b/package/api/src/controllers/v1/groups/mod.rs
@@ -189,6 +189,14 @@ impl GroupControllerV1 {
         let mut groups: Vec<GroupResponse> = vec![];
 
         for group in res.items {
+            if group.deleted_at.is_some() {
+                continue;
+            }
+
+            if group.organization_id != organization_id {
+                continue;
+            }
+            println!("hey {:?}", GroupMember::get_gsi1(&group.id));
             //FIXME: fix to parameter
             let res: CommonQueryResponse<GroupMember> = CommonQueryResponse::query(
                 &log,
@@ -469,7 +477,7 @@ impl GroupControllerV1 {
         if res.items.len() == 0 {
             //group member not exists
             let id = uuid::Uuid::new_v4().to_string();
-            let group_member = GroupMember::new(id, group_id, member.organization_id.clone());
+            let group_member = GroupMember::new(id, group_id, member.id.clone());
 
             match cli.upsert(group_member.clone()).await {
                 Ok(()) => {
@@ -496,7 +504,7 @@ impl GroupControllerV1 {
 
             if item.deleted_at.is_some() {
                 let group_member =
-                    GroupMember::new(item.id.clone(), group_id, member.organization_id.clone());
+                    GroupMember::new(item.id.clone(), group_id, member.id.clone());
 
                 match cli.upsert(group_member.clone()).await {
                     Ok(()) => {
@@ -598,7 +606,7 @@ impl GroupControllerV1 {
         cli.create(GroupMember::new(
             uuid::Uuid::new_v4().to_string(),
             group_id.to_string(),
-            req.id.clone(),
+            req.member_id.clone(),
         ))
         .await
         .map_err(|e| ApiError::DynamoCreateException(e.to_string()))?;

--- a/package/api/src/controllers/v1/groups/mod.rs
+++ b/package/api/src/controllers/v1/groups/mod.rs
@@ -76,7 +76,7 @@ impl GroupControllerV1 {
                                     ctrl.clone(),
                                     id.clone(),
                                     req.name.clone(),
-                                    member.user_id,
+                                    member.member_id,
                                 )
                                 .await?;
                         }
@@ -582,7 +582,7 @@ impl GroupControllerV1 {
         let cli = easy_dynamodb::get_client(&log);
 
         let res = cli
-            .get::<OrganizationMember>(&req.id)
+            .get::<OrganizationMember>(&req.member_id)
             .await
             .map_err(|e| ApiError::DynamoQueryException(e.to_string()))?;
 

--- a/package/api/src/controllers/v1/members/mod.rs
+++ b/package/api/src/controllers/v1/members/mod.rs
@@ -59,7 +59,7 @@ impl MemberControllerV1 {
                     "gsi1-index",
                     None,
                     Some(100),
-                    vec![("gsi1", Member::get_gsi1(req.email.clone()))],
+                    vec![("gsi1", Member::get_gsi1("".to_string()))],
                 )
                 .await?;
 
@@ -71,10 +71,11 @@ impl MemberControllerV1 {
                     if item.deleted_at.is_some() {
                         let mem: Member = (
                             CreateMemberRequest {
-                                email: req.email,
                                 name: None,
                                 group: None,
                                 role: None,
+                                user_id: req.user_id.clone(),
+                                org_id: organization_id.clone(),
                             },
                             item.id.clone(),
                         )
@@ -139,7 +140,6 @@ impl MemberControllerV1 {
         Ok(())
     }
 
-    //TODO: implement invite member in organization
     pub async fn invite_member(
         Extension(organizations): Extension<OrganizationMiddlewareParams>,
         State(ctrl): State<MemberControllerV1>,
@@ -150,13 +150,38 @@ impl MemberControllerV1 {
         let cli = easy_dynamodb::get_client(&log);
         slog::debug!(log, "invite_member: {:?} {:?}", organization_id, body);
 
+        let res: CommonQueryResponse<User> = CommonQueryResponse::query(
+            &log,
+            "gsi1-index",
+            None,
+            Some(1),
+            vec![("gsi1", User::gsi1(body.email.clone()))],
+        )
+        .await?;
+
+        if res.items.len() == 0 {
+            return Err(ApiError::NotFound);
+        }
+
+        let user = match res.items.first() {
+            Some(user) => {
+                if user.deleted_at.is_some() {
+                    return Err(ApiError::NotFound);
+                }
+                user
+            }
+            None => return Err(ApiError::NotFound),
+        };
+
+        let user_id = user.id.clone();
+
         // check org member exists
         let res: CommonQueryResponse<OrganizationMember> = CommonQueryResponse::query(
             &log,
             "gsi1-index",
             None,
             Some(1),
-            vec![("gsi1", OrganizationMember::get_gsi2(&body.user_id.clone(), &organization_id.clone()))],
+            vec![("gsi1", OrganizationMember::get_gsi2(&user_id.clone(), &organization_id.clone()))],
         )
         .await?;
 
@@ -168,7 +193,7 @@ impl MemberControllerV1 {
 
         let member: OrganizationMember = (
             CreateMemberRequest {
-                user_id: body.user_id.clone(),
+                user_id: user_id.clone(),
                 org_id: organization_id.clone(),
                 name: Some(body.name.clone()),
                 group: body.group.clone(),
@@ -234,6 +259,7 @@ impl MemberControllerV1 {
         let organization_id = organizations.id;
         let log = ctrl.log.new(o!("api" => "list_members"));
         slog::debug!(log, "list_members {:?} {:?}", organization_id, pagination);
+        let cli = easy_dynamodb::get_client(&log);
 
         let size = if let Some(size) = pagination.size {
             if size > 100 {
@@ -277,8 +303,49 @@ impl MemberControllerV1 {
             role_count[0] += 1;
         });
 
+        let mut result: Vec<GroupMemberRelationship> = Vec::new();
+
+        for item in filtered.iter() {
+            let mut groups: Vec<Group> = Vec::new();
+
+            let res: CommonQueryResponse<GroupMember> = CommonQueryResponse::query(
+                &log,
+                "gsi2-index",
+                None,
+                Some(100),
+                vec![("gsi2", GroupMember::get_gsi2(&item.id.clone()))],
+            )
+            .await?;
+
+            for item in res.items {
+                if item.deleted_at.is_some() {
+                    continue;
+                }
+
+                let group = cli
+                    .get::<Group>(&item.group_id)
+                    .await
+                    .map_err(|e| ApiError::DynamoQueryException(e.to_string()))?;
+
+                if group.is_none() {
+                    continue;
+                }
+
+                if group.clone().unwrap().deleted_at.is_some() {
+                    continue;
+                }
+
+                groups.push(group.unwrap());
+            }
+
+            result.push(GroupMemberRelationship {
+                member: item.clone(),
+                groups,
+            });
+        }
+
         Ok(Json(ListMemberResponse {
-            members: filtered,
+            members: result,
             role_count,
             bookmark: res.bookmark,
         }))
@@ -288,30 +355,60 @@ impl MemberControllerV1 {
         Extension(organizations): Extension<OrganizationMiddlewareParams>,
         State(ctrl): State<MemberControllerV1>,
         Path(member_id): Path<String>,
-    ) -> Result<Json<OrganizationMember>, ApiError> {
+    ) -> Result<Json<GroupMemberRelationship>, ApiError> {
         let organization_id = organizations.id;
         let log = ctrl.log.new(o!("api" => "get_member"));
         slog::debug!(log, "get_member {:?} {:?}", organization_id, member_id);
         let cli = easy_dynamodb::get_client(&log);
 
-        let res = cli.get::<OrganizationMember>(&member_id).await;
+        let res = cli
+            .get::<OrganizationMember>(&member_id)
+            .await
+            .map_err(|e| ApiError::DynamoQueryException(e.to_string()))?;
 
-        match res {
-            Ok(v) => match v {
-                Some(v) => {
-                    if v.deleted_at.is_none() {
-                        Ok(Json(v))
-                    } else {
-                        Err(ApiError::NotFound)
-                    }
-                }
-                None => Err(ApiError::NotFound),
-            },
-            Err(e) => {
-                slog::error!(log, "Member Query Failed {e:?}");
-                Err(ApiError::DynamoQueryException(e.to_string()))
-            }
+        if res.is_none() {
+            return Err(ApiError::NotFound);
         }
+
+        let member = res.unwrap();
+
+        let mut groups: Vec<Group> = Vec::new();
+
+        let res: CommonQueryResponse<GroupMember> = CommonQueryResponse::query(
+            &log,
+            "gsi2-index",
+            None,
+            Some(100),
+            vec![("gsi2", GroupMember::get_gsi2(&member.id.clone()))],
+        )
+        .await?;
+
+        for item in res.items {
+            if item.deleted_at.is_some() {
+                continue;
+            }
+
+            let group = cli
+                .get::<Group>(&item.group_id)
+                .await
+                .map_err(|e| ApiError::DynamoQueryException(e.to_string()))?;
+
+            if group.is_none() {
+                continue;
+            }
+
+            if group.clone().unwrap().deleted_at.is_some() {
+                continue;
+            }
+
+            groups.push(group.unwrap());
+        }
+
+        Ok(Json(GroupMemberRelationship {
+            member,
+            groups,
+        }))
+        
     }
 }
 

--- a/package/api/src/controllers/v1/members/mod.rs
+++ b/package/api/src/controllers/v1/members/mod.rs
@@ -76,6 +76,7 @@ impl MemberControllerV1 {
                                 role: None,
                                 user_id: req.user_id.clone(),
                                 org_id: organization_id.clone(),
+                                email: req.email.clone(),
                             },
                             item.id.clone(),
                         )
@@ -198,6 +199,7 @@ impl MemberControllerV1 {
                 name: Some(body.name.clone()),
                 group: body.group.clone(),
                 role: body.role,
+                email: body.email.clone(),
             },
             id.clone(),
         )
@@ -341,6 +343,7 @@ impl MemberControllerV1 {
             result.push(GroupMemberRelationship {
                 member: item.clone(),
                 groups,
+                project: vec![], // TODO: implement projects
             });
         }
 
@@ -407,6 +410,7 @@ impl MemberControllerV1 {
         Ok(Json(GroupMemberRelationship {
             member,
             groups,
+            project: vec![], // TODO: implement projects
         }))
         
     }

--- a/package/models/src/group/mod.rs
+++ b/package/models/src/group/mod.rs
@@ -148,9 +148,9 @@ impl Group {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
 pub struct CreateGroupMember {
-    pub user_id: String,
-    pub user_name: String,
-    pub user_email: String,
+    pub member_id: String,
+    pub member_name: String,
+    pub member_email: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
@@ -184,7 +184,6 @@ impl Into<Group> for (CreateGroupRequest, String, String, String) {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, Eq)]
 pub struct TeamMemberRequest {
-    pub id: String,
     pub member_id: String,
     pub email: String,
     pub name: Option<String>,

--- a/package/models/src/group/mod.rs
+++ b/package/models/src/group/mod.rs
@@ -188,6 +188,7 @@ impl Into<Group> for (CreateGroupRequest, String, String, String) {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, Eq)]
 pub struct TeamMemberRequest {
     pub id: String,
+    pub member_id: String,
     pub email: String,
     pub name: Option<String>,
     pub group: Option<GroupInfo>,

--- a/package/models/src/member/mod.rs
+++ b/package/models/src/member/mod.rs
@@ -30,9 +30,15 @@ pub struct Member {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ListMemberResponse {
-    pub members: Vec<OrganizationMember>,
+    pub members: Vec<GroupMemberRelationship>,
     pub role_count: Vec<u64>,
     pub bookmark: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GroupMemberRelationship {
+    pub member: OrganizationMember,
+    pub groups: Vec<Group>,
 }
 
 // FIXME: depreciated data structure (-> OrganizationMember)
@@ -140,7 +146,6 @@ impl InviteMember {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, Eq)]
 pub struct InviteMemberRequest {
-    pub user_id: String,
     pub email: String,
     pub name: String,
     pub group: Option<GroupInfo>,

--- a/package/models/src/member/mod.rs
+++ b/package/models/src/member/mod.rs
@@ -39,6 +39,7 @@ pub struct ListMemberResponse {
 pub struct GroupMemberRelationship {
     pub member: OrganizationMember,
     pub groups: Vec<Group>,
+    pub project: Vec<MemberProject>,
 }
 
 // FIXME: depreciated data structure (-> OrganizationMember)
@@ -182,6 +183,7 @@ pub struct CreateMemberRequest {
     pub name: Option<String>,
     pub group: Option<GroupInfo>,
     pub role: Option<Role>,
+    pub email: String,
     // pub projects: Option<Vec<MemberProject>>,
 }
 

--- a/package/models/src/member/mod.rs
+++ b/package/models/src/member/mod.rs
@@ -1,5 +1,9 @@
 use serde::{Deserialize, Serialize};
-use crate::organization::OrganizationMember;
+use crate::{
+    organization::OrganizationMember,
+    group::Group,
+};
+use crate::prelude::Role;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, Eq)]
 pub struct MemberProject {
@@ -87,7 +91,7 @@ pub struct InviteMember {
     pub email: String,
     pub name: String,
     pub group: Option<GroupInfo>,
-    pub role: Option<String>,
+    pub role: Option<Role>,
     pub projects: Option<Vec<MemberProject>>, //FIXME: implement project model sepalately after public opinion, investigation api implemented
 }
 
@@ -97,7 +101,7 @@ impl InviteMember {
         email: String,
         name: String,
         group: Option<GroupInfo>,
-        role: Option<String>,
+        role: Option<Role>,
         projects: Option<Vec<MemberProject>>,
     ) -> Self {
         let now = chrono::Utc::now().timestamp_millis();
@@ -136,10 +140,11 @@ impl InviteMember {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, Eq)]
 pub struct InviteMemberRequest {
+    pub user_id: String,
     pub email: String,
     pub name: String,
     pub group: Option<GroupInfo>,
-    pub role: Option<String>,
+    pub role: Option<Role>,
     pub projects: Option<Vec<MemberProject>>,
 }
 
@@ -167,10 +172,11 @@ impl Into<InviteMember> for (InviteMemberRequest, String) {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct CreateMemberRequest {
-    pub email: String,
+    pub user_id: String,
+    pub org_id: String,
     pub name: Option<String>,
     pub group: Option<GroupInfo>,
-    pub role: Option<String>,
+    pub role: Option<Role>,
     // pub projects: Option<Vec<MemberProject>>,
 }
 
@@ -178,6 +184,17 @@ pub struct CreateMemberRequest {
 pub struct GroupInfo {
     pub id: String,
     pub name: String,
+}
+
+impl TryFrom<Group> for GroupInfo {
+    type Error = std::fmt::Error;
+
+    fn try_from(group: Group) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: group.id,
+            name: group.name,
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, Eq)]
@@ -196,18 +213,18 @@ impl Into<Member> for (CreateMemberRequest, String) {
         Member {
             id,
             r#type: Member::get_type(),
-            gsi1: Member::get_gsi1(req.email.clone()),
+            gsi1: Member::get_gsi1("".to_string()), // deprecated
             created_at: now,
             updated_at: now,
             deleted_at: None,
-            email: req.email,
+            email: "".to_string(), // deprecated
             name: req.name,
             group: if req.group.is_none() {
                 None
             } else {
                 Some(req.group.unwrap().name)
             },  
-            role: req.role,
+            role: Some("".to_string()), // deprecated
             // projects: req.projects,
         }
     }

--- a/package/models/src/organization/mod.rs
+++ b/package/models/src/organization/mod.rs
@@ -25,6 +25,7 @@ pub struct OrganizationMember {
     pub r#type: String,
     pub gsi1: String, //user_id
     pub gsi2: String, //user_id#organization_id
+    pub email: String, // FIXME: remove this field if postgre is implemented
     pub created_at: i64,
     pub updated_at: i64,
     pub deleted_at: Option<i64>,
@@ -50,7 +51,7 @@ impl OrganizationMember {
 
         organization_member.user_id = user_id;
         organization_member.organization_id = organization_id;
-
+    
         if let Some(r) = role {
             organization_member.role = Some(r);
         };
@@ -105,6 +106,7 @@ impl Into<OrganizationMember> for (CreateMemberRequest, String) {
             deleted_at: None,
             name: req.name,
             role: req.role,
+            email: req.email,
             // projects: req.projects,
         }
     }

--- a/package/models/src/organization/mod.rs
+++ b/package/models/src/organization/mod.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use crate::member::CreateMemberRequest;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct OrganizationMemberResponse {
@@ -30,7 +31,7 @@ pub struct OrganizationMember {
 }
 
 impl OrganizationMember {
-    pub fn new(id: String, user_id: String, organization_id: String) -> Self {
+    pub fn new(id: String, user_id: String, organization_id: String, role: Option<Role>) -> Self {
         //uuid, user_id, organization_id
         let mut organization_member = OrganizationMember::default();
         let now = chrono::Utc::now().timestamp_millis();
@@ -44,6 +45,10 @@ impl OrganizationMember {
 
         organization_member.user_id = user_id;
         organization_member.organization_id = organization_id;
+
+        if let Some(r) = role {
+            organization_member.role = Some(r);
+        };
 
         organization_member
     }
@@ -75,6 +80,28 @@ impl OrganizationMember {
 
     pub fn get_type() -> String {
         "organization#member".to_string()
+    }
+}
+
+impl Into<OrganizationMember> for (CreateMemberRequest, String) {
+    fn into(self) -> OrganizationMember {
+        let (req, id) = self;
+        let now = chrono::Utc::now().timestamp_millis();
+
+        OrganizationMember {
+            id,
+            r#type: OrganizationMember::get_type(),
+            gsi1: OrganizationMember::get_gsi1(&req.user_id),
+            gsi2: OrganizationMember::get_gsi2(&req.user_id, &req.org_id),
+            user_id: req.user_id,
+            organization_id: req.org_id,
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+            name: req.name,
+            role: req.role,
+            // projects: req.projects,
+        }
     }
 }
 


### PR DESCRIPTION
1. invite member 로직 추가
2. 자기 자신의 조직에 추가될 땐 자신이 관리자가 되도록 세팅
3. Create Group 하고 List 조회시 내 organization이 아닌 전체 리스트가 조회되고 있음
4. Create Group 시 멤버 추가해서 실행 후 Get Group을 수행했을 때 members에 빈 리스트가 조회되고 있음. member가 추가되도록 수정
5. list/get_organization_member에 대해서 리턴값에 +name, email, 속한 groups id, group name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced member and group management with improved role and relationship tracking.
  - Updated member identification process across multiple controllers.

- **Bug Fixes**
  - Improved data integrity checks for groups and members.
  - Added safeguards to prevent access to deleted groups and users.

- **Refactor**
  - Restructured data models for members, groups, and organizations.
  - Simplified member and group creation logic.
  - Updated method signatures to improve type safety and clarity.

- **Chores**
  - Renamed fields to improve semantic clarity.
  - Deprecated certain identification methods.

The changes focus on enhancing the backend's member and group management system with more robust data handling and improved type definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->