### PR TITLE
*** feat(api): add discussion controller and routes

### DIFF
--- a/packages/api/src/controllers/v2/deliberations/_id/comments.rs
+++ b/packages/api/src/controllers/v2/deliberations/_id/comments.rs
@@ -29,7 +29,7 @@ impl DeliberationCommentController {
         param: DeliberationCommentQuery,
     ) -> Result<QueryResponse<DeliberationCommentSummary>> {
         let user_id = match auth {
-            Some(Authorization::Bearer { claims }) => AppClaims(claims).get_user_id(),
+            Some(Authorization::Bearer { ref claims }) => AppClaims(claims).get_user_id(),
             _ => 0,
         };
         let parent_id = param.parent_id.unwrap_or_default();
@@ -64,7 +64,7 @@ impl DeliberationCommentController {
         param: DeliberationCommentQuery,
     ) -> Result<QueryResponse<DeliberationCommentSummary>> {
         let user_id = match auth {
-            Some(Authorization::Bearer { claims }) => AppClaims(claims).get_user_id(),
+            Some(Authorization::Bearer { ref claims }) => AppClaims(claims).get_user_id(),
             _ => 0,
         };
 
@@ -95,7 +95,7 @@ impl DeliberationCommentController {
         DeliberationCommentCommentRequest { comment }: DeliberationCommentCommentRequest,
     ) -> Result<DeliberationComment> {
         let user_id = match auth {
-            Some(Authorization::Bearer { claims }) => AppClaims(claims).get_user_id(),
+            Some(Authorization::Bearer { ref claims }) => AppClaims(claims).get_user_id(),
             _ => return Err(ApiError::Unauthorized),
         };
 
@@ -115,7 +115,7 @@ impl DeliberationCommentController {
         DeliberationCommentReplyToCommentRequest { comment }: DeliberationCommentReplyToCommentRequest,
     ) -> Result<DeliberationComment> {
         let user_id = match auth {
-            Some(Authorization::Bearer { claims }) => AppClaims(claims).get_user_id(),
+            Some(Authorization::Bearer { ref claims }) => AppClaims(claims).get_user_id(),
             _ => return Err(ApiError::Unauthorized),
         };
 
@@ -133,7 +133,7 @@ impl DeliberationCommentController {
         auth: Option<Authorization>,
     ) -> Result<DeliberationComment> {
         let user_id = match auth {
-            Some(Authorization::Bearer { claims }) => AppClaims(claims).get_user_id(),
+            Some(Authorization::Bearer { ref claims }) => AppClaims(claims).get_user_id(),
             _ => return Err(ApiError::Unauthorized),
         };
 

--- a/packages/api/src/controllers/v2/deliberations/_id/discussions.rs
+++ b/packages/api/src/controllers/v2/deliberations/_id/discussions.rs
@@ -1,0 +1,382 @@
+use by_axum::{
+    aide,
+    auth::Authorization,
+    axum::{
+        extract::{Path, Query, State},
+        routing::{get, post},
+        Extension, Json,
+    },
+};
+use by_types::QueryResponse;
+use deliberation::Deliberation;
+use discussion_resources::DiscussionResource;
+use discussions::*;
+use models::*;
+use sqlx::postgres::PgRow;
+
+use crate::utils::app_claims::AppClaims;
+
+#[derive(Clone, Debug)]
+pub struct DiscussionController {
+    repo: DiscussionRepository,
+    pool: sqlx::Pool<sqlx::Postgres>,
+}
+
+impl DiscussionController {
+    async fn query(
+        &self,
+        deliberation_id: i64,
+        _auth: Option<Authorization>,
+        param: DiscussionQuery,
+    ) -> Result<QueryResponse<DiscussionSummary>> {
+        let mut total_count = 0;
+        let items: Vec<DiscussionSummary> = DiscussionSummary::query_builder()
+            .limit(param.size())
+            .page(param.page())
+            .deliberation_id_equals(deliberation_id)
+            .query()
+            .map(|row: PgRow| {
+                use sqlx::Row;
+
+                total_count = row.try_get("total_count").unwrap_or_default();
+                row.into()
+            })
+            .fetch_all(&self.pool)
+            .await?;
+
+        Ok(QueryResponse { total_count, items })
+    }
+
+    async fn start_meeting(&self, _id: i64, _auth: Option<Authorization>) -> Result<Discussion> {
+        todo!()
+    }
+
+    async fn create(
+        &self,
+        deliberation_id: i64,
+        auth: Option<Authorization>,
+        DiscussionCreateRequest {
+            started_at,
+            ended_at,
+            name,
+            description,
+            resources,
+        }: DiscussionCreateRequest,
+    ) -> Result<Discussion> {
+        let user_id = match auth {
+            Some(Authorization::Bearer { ref claims }) => AppClaims(claims).get_user_id(),
+            _ => return Err(ApiError::Unauthorized),
+        };
+
+        let repo = DiscussionResource::get_repository(self.pool.clone());
+
+        let mut tx = self.pool.begin().await?;
+
+        let deliberation = Deliberation::query_builder()
+            .id_equals(deliberation_id)
+            .query()
+            .map(Deliberation::from)
+            .fetch_optional(&self.pool)
+            .await?
+            .ok_or(ApiError::DeliberationNotFound)?;
+
+        let user = User::query_builder()
+            .id_equals(user_id)
+            .query()
+            .map(User::from)
+            .fetch_optional(&self.pool)
+            .await?
+            .ok_or(ApiError::NoUser)?;
+
+        user.orgs
+            .iter()
+            .find(|org| org.id == deliberation.org_id)
+            .ok_or(ApiError::NoUser)?;
+
+        let res = self
+            .repo
+            .insert_with_tx(
+                &mut *tx,
+                deliberation_id,
+                started_at,
+                ended_at,
+                name,
+                description,
+                None,
+            )
+            .await?
+            .ok_or(ApiError::DeliberationNotFound)?;
+
+        let org_id = deliberation.org_id;
+
+        for resource_id in resources {
+            let rsc = ResourceFile::query_builder()
+                .id_equals(resource_id)
+                .query()
+                .map(ResourceFile::from)
+                .fetch_optional(&self.pool)
+                .await?
+                .ok_or(ApiError::ResourceNotFound)?;
+
+            if rsc.org_id != org_id {
+                tracing::error!("It seems to try abusing system: {auth:?}. It used invalid resource: {resource_id} {org_id}");
+                return Err(ApiError::ResourceNotPermitted)?;
+            }
+
+            repo.insert_with_tx(&mut *tx, res.id, resource_id)
+                .await?
+                .ok_or(ApiError::ResourceNotFound)?;
+        }
+
+        let res = Discussion::query_builder()
+            .id_equals(res.id)
+            .query()
+            .map(Discussion::from)
+            .fetch_optional(&self.pool)
+            .await?
+            .ok_or(ApiError::DiscussionNotFound)?;
+
+        tx.commit().await?;
+
+        Ok(res)
+    }
+
+    async fn update(
+        &self,
+        id: i64,
+        auth: Option<Authorization>,
+        param: DiscussionUpdateRequest,
+    ) -> Result<Discussion> {
+        if auth.is_none() {
+            return Err(ApiError::Unauthorized);
+        }
+
+        let res = self.repo.update(id, param.into()).await?;
+
+        Ok(res)
+    }
+
+    async fn delete(&self, id: i64, auth: Option<Authorization>) -> Result<Discussion> {
+        if auth.is_none() {
+            return Err(ApiError::Unauthorized);
+        }
+
+        let res = self.repo.delete(id).await?;
+
+        Ok(res)
+    }
+
+    // async fn run_read_action(
+    //     &self,
+    //     _auth: Option<Authorization>,
+    //     DiscussionReadAction { action, .. }: DiscussionReadAction,
+    // ) -> Result<Discussion> {
+    //     todo!()
+    // }
+}
+
+impl DiscussionController {
+    pub fn new(pool: sqlx::Pool<sqlx::Postgres>) -> Self {
+        let repo = Discussion::get_repository(pool.clone());
+
+        Self { repo, pool }
+    }
+
+    pub fn route(&self) -> by_axum::axum::Router {
+        by_axum::axum::Router::new()
+            .route(
+                "/:id",
+                get(Self::get_discussion_by_id).post(Self::act_discussion_by_id),
+            )
+            .with_state(self.clone())
+            .route("/", post(Self::act_discussion).get(Self::get_discussion))
+            .with_state(self.clone())
+    }
+
+    pub async fn act_discussion(
+        State(ctrl): State<DiscussionController>,
+        Path(DiscussionParentPath { deliberation_id }): Path<DiscussionParentPath>,
+        Extension(auth): Extension<Option<Authorization>>,
+        Json(body): Json<DiscussionAction>,
+    ) -> Result<Json<Discussion>> {
+        tracing::debug!("act_discussion {} {:?}", deliberation_id, body);
+        match body {
+            DiscussionAction::Create(param) => {
+                let res = ctrl.create(deliberation_id, auth, param).await?;
+                Ok(Json(res))
+            }
+        }
+    }
+
+    pub async fn act_discussion_by_id(
+        State(ctrl): State<DiscussionController>,
+        Extension(auth): Extension<Option<Authorization>>,
+        Path(DiscussionPath {
+            deliberation_id,
+            id,
+        }): Path<DiscussionPath>,
+        Json(body): Json<DiscussionByIdAction>,
+    ) -> Result<Json<Discussion>> {
+        tracing::debug!(
+            "act_discussion_by_id {} {:?} {:?}",
+            deliberation_id,
+            id,
+            body
+        );
+
+        match body {
+            DiscussionByIdAction::Update(param) => {
+                let res = ctrl.update(id, auth, param).await?;
+                Ok(Json(res))
+            }
+            DiscussionByIdAction::Delete(_) => {
+                let res = ctrl.delete(id, auth).await?;
+                Ok(Json(res))
+            }
+
+            DiscussionByIdAction::StartMeeting(_) => {
+                let res = ctrl.start_meeting(id, auth).await?;
+                Ok(Json(res))
+            }
+        }
+    }
+
+    pub async fn get_discussion_by_id(
+        State(ctrl): State<DiscussionController>,
+        Extension(_auth): Extension<Option<Authorization>>,
+        Path(DiscussionPath {
+            deliberation_id,
+            id,
+        }): Path<DiscussionPath>,
+    ) -> Result<Json<Discussion>> {
+        tracing::debug!("get_discussion {} {:?}", deliberation_id, id);
+        Ok(Json(
+            Discussion::query_builder()
+                .id_equals(id)
+                .deliberation_id_equals(deliberation_id)
+                .query()
+                .map(Discussion::from)
+                .fetch_one(&ctrl.pool)
+                .await?,
+        ))
+    }
+
+    pub async fn get_discussion(
+        State(ctrl): State<DiscussionController>,
+        Path(DiscussionParentPath { deliberation_id }): Path<DiscussionParentPath>,
+        Extension(auth): Extension<Option<Authorization>>,
+        Query(q): Query<DiscussionParam>,
+    ) -> Result<Json<DiscussionGetResponse>> {
+        tracing::debug!("list_discussion {} {:?}", deliberation_id, q);
+
+        match q {
+            DiscussionParam::Query(param) => Ok(Json(DiscussionGetResponse::Query(
+                ctrl.query(deliberation_id, auth, param).await?,
+            ))),
+            // DiscussionParam::Read(param)
+            //     if param.action == Some(DiscussionReadActionType::ActionType) =>
+            // {
+            //     let res = ctrl.run_read_action(auth, param).await?;
+            //     Ok(Json(DiscussionGetResponse::Read(res)))
+            // }
+        }
+    }
+}
+
+#[derive(
+    Debug, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema, aide::OperationIo,
+)]
+#[serde(rename_all = "kebab-case")]
+pub struct DiscussionPath {
+    pub deliberation_id: i64,
+    pub id: i64,
+}
+
+#[derive(
+    Debug, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema, aide::OperationIo,
+)]
+#[serde(rename_all = "kebab-case")]
+pub struct DiscussionParentPath {
+    pub deliberation_id: i64,
+}
+
+#[cfg(test)]
+mod discussion_tests {
+    use crate::tests::{setup, TestContext};
+
+    use super::*;
+
+    async fn create_deliberation(endpoint: &str, org_id: i64, now: i64) -> i64 {
+        let get_client = Deliberation::get_client(endpoint);
+        let cli = get_client;
+        let res = cli
+            .create(
+                org_id,
+                now,
+                now + 1000,
+                ProjectArea::City,
+                format!("test deliberation {now}"),
+                "test description".to_string(),
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+            )
+            .await;
+        assert!(res.is_ok());
+
+        res.unwrap().id
+    }
+
+    #[tokio::test]
+    async fn test_create_discussion() {
+        let TestContext {
+            user,
+            now,
+            endpoint,
+            ..
+        } = setup().await.unwrap();
+        let org_id = user.orgs[0].id;
+
+        let deliberation_id = create_deliberation(&endpoint, org_id, now).await;
+
+        let cli = Discussion::get_client(&endpoint);
+        let started_at = now;
+        let ended_at = now + 10000;
+        let name = "test discussion".to_string();
+        let description = "test description".to_string();
+
+        let discussion = cli
+            .create(
+                deliberation_id,
+                started_at,
+                ended_at,
+                name.clone(),
+                description.clone(),
+                vec![],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(discussion.deliberation_id, deliberation_id);
+        assert_eq!(discussion.started_at, started_at);
+        assert_eq!(discussion.ended_at, ended_at);
+        assert_eq!(discussion.name, name);
+        assert_eq!(discussion.description, description);
+
+        let got = Discussion::get_client(&endpoint)
+            .get(deliberation_id, discussion.id)
+            .await
+            .unwrap();
+
+        assert_eq!(got.id, discussion.id);
+        assert_eq!(got.deliberation_id, deliberation_id);
+        assert_eq!(got.started_at, started_at);
+        assert_eq!(got.ended_at, ended_at);
+        assert_eq!(got.name, name);
+        assert_eq!(got.description, description);
+    }
+}

--- a/packages/api/src/controllers/v2/deliberations/_id/discussions.rs
+++ b/packages/api/src/controllers/v2/deliberations/_id/discussions.rs
@@ -48,6 +48,7 @@ impl DiscussionController {
     }
 
     async fn start_meeting(&self, _id: i64, _auth: Option<Authorization>) -> Result<Discussion> {
+        // TODO(api): implement using AWS chime and media pipeline.
         todo!()
     }
 
@@ -100,8 +101,8 @@ impl DiscussionController {
                 .ok_or(ApiError::ResourceNotFound)?;
 
             if rsc.org_id != org_id {
-                tracing::error!("It seems to try abusing system: {auth:?}. It used invalid resource: {resource_id} {org_id}");
-                return Err(ApiError::ResourceNotPermitted)?;
+                tracing::error!("It seems to try abusing system: user_id: {user_id}. It used invalid resource: {resource_id} {org_id}");
+                return Err(ApiError::ResourceNotPermitted);
             }
 
             repo.insert_with_tx(&mut *tx, res.id, resource_id)

--- a/packages/api/src/controllers/v2/deliberations/_id/discussions.rs
+++ b/packages/api/src/controllers/v2/deliberations/_id/discussions.rs
@@ -174,6 +174,8 @@ impl DiscussionController {
             .await?
             .ok_or(ApiError::DiscussionNotFound)?;
 
+        tx.commit().await?;
+
         Ok(res)
     }
 

--- a/packages/api/src/controllers/v2/deliberations/_id/discussions.rs
+++ b/packages/api/src/controllers/v2/deliberations/_id/discussions.rs
@@ -96,7 +96,7 @@ impl DiscussionController {
                 .id_equals(resource_id)
                 .query()
                 .map(ResourceFile::from)
-                .fetch_optional(&self.pool)
+                .fetch_optional(&mut *tx)
                 .await?
                 .ok_or(ApiError::ResourceNotFound)?;
 
@@ -114,7 +114,7 @@ impl DiscussionController {
             .id_equals(res.id)
             .query()
             .map(Discussion::from)
-            .fetch_optional(&self.pool)
+            .fetch_optional(&mut *tx)
             .await?
             .ok_or(ApiError::DiscussionNotFound)?;
 

--- a/packages/api/src/controllers/v2/mod.rs
+++ b/packages/api/src/controllers/v2/mod.rs
@@ -15,6 +15,7 @@ pub mod surveys {
 pub mod deliberations {
     pub mod _id {
         pub mod comments;
+        pub mod discussions;
         pub mod responses;
     }
 }
@@ -45,6 +46,10 @@ impl Version2Controller {
             .nest(
                 "/surveys/:survey-id/responses",
                 surveys::_id::responses::SurveyResponseController::route(pool.clone())?,
+            )
+            .nest(
+                "/deliberations/:deliberation-id/discussions",
+                deliberations::_id::discussions::DiscussionController::new(pool.clone()).route(),
             )
             .nest(
                 "/deliberations/:deliberation-id/comments",

--- a/packages/api/src/utils/app_claims.rs
+++ b/packages/api/src/utils/app_claims.rs
@@ -5,10 +5,10 @@ use by_axum::auth::generate_jwt;
 use by_types::Claims;
 use models::{ApiError, User};
 
-pub struct AppClaims(pub Claims);
+pub struct AppClaims<'a>(pub &'a Claims);
 
-impl AppClaims {
-    pub fn new(claims: Claims) -> Self {
+impl<'a> AppClaims<'a> {
+    pub fn new(claims: &'a Claims) -> Self {
         Self(claims)
     }
 

--- a/packages/models/src/discussions/discussion.rs
+++ b/packages/models/src/discussions/discussion.rs
@@ -6,12 +6,9 @@ use validator::Validate;
 use crate::{ResourceFile, User};
 
 // TODO(web): using resource for discussion tab on a project
-// TODO(api): implement Create action(create) of POST /v2/deliberations/:deliberation-id/discussions
-// TODO(api): implement query action(query) of GET /v2/deliberations/:deliberation-id/discussions
 // TODO(api): implement action_by_id action(start_meeting) of POST /v2/deliberations/:deliberation-id/discussions/:id
-// TODO(api): implement GET /v2/deliberations/:deliberation-id/discussions/:id
 #[derive(Validate)]
-#[api_model(base = "/v2/deliberations/:deliberation-id/discussions", table = discussions, action = [create(resources = Vec<i64>)], action_by_id = start_meeting)]
+#[api_model(base = "/v2/deliberations/:deliberation-id/discussions", table = discussions, action = [create(resources = Vec<i64>)], action_by_id = [start_meeting, delete])]
 pub struct Discussion {
     #[api_model(summary, primary_key)]
     pub id: i64,

--- a/packages/models/src/error.rs
+++ b/packages/models/src/error.rs
@@ -88,9 +88,20 @@ pub enum ApiError {
 
     OrganizationNotFound,
 
+    InvalidType,
+
+    // Resource Errors
+    #[translate(
+        ko = "참고자료 또는 파일을 찾을 수 없습니다.",
+        en = "Cannot find the reference or file."
+    )]
     ResourceNotFound,
 
-    InvalidType,
+    #[translate(
+        ko = "자료에 접근권한이 없습니다.",
+        en = "No access permission to the resource."
+    )]
+    ResourceNotPermitted,
 
     // Survey Errors
     SurveyAlreadyExists,
@@ -173,6 +184,15 @@ pub enum ApiError {
         en = "Please check the attached file in the discussion."
     )]
     DiscussionResourceException,
+
+    #[translate(
+        ko = "토론에 참여한 사용자를 확인해주세요.",
+        en = "Please check the users who participated in the discussion."
+    )]
+    DiscussionUserException,
+
+    #[translate(ko = "토론을 찾을 수 없습니다.", en = "Cannot find the discussion.")]
+    DiscussionNotFound,
 }
 
 impl From<reqwest::Error> for ApiError {


### PR DESCRIPTION
Resolves #190

+ Add ~DiscussionController~ with CRUD operations
+ Implement routes for discussions under deliberations
+ Update ~AppClaims~ to use references
+ Add new error types for discussions and resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced discussion management capabilities that let end-users create, retrieve, update, and delete discussion threads within deliberations.
  - Expanded discussion actions by adding a deletion option, enhancing collaboration and moderation.

- **Bug Fixes**
  - Enhanced error responses for discussion operations, providing clearer notifications for authorization and resource access issues.
  - Added new error types for improved clarity on discussion-related issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->