### PR TITLE
fix survey modal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "main-ui"
-version = "0.3.24"
+version = "0.3.25"
 dependencies = [
  "bdk",
  "by-components",

--- a/packages/main-ui/Cargo.toml
+++ b/packages/main-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "main-ui"
-version = "0.3.24"
+version = "0.3.25"
 authors.workspace = true
 edition.workspace = true
 

--- a/packages/main-ui/src/pages/surveys/components/start_project_modal.rs
+++ b/packages/main-ui/src/pages/surveys/components/start_project_modal.rs
@@ -36,17 +36,17 @@ translate! {
     StartProjectModalTranslate;
 
     title: {
-        ko: "프로젝트 시작",
-        en: "Start Project"
+        ko: "설문 시작 안내",
+        en: "Instructions for starting the survey"
     }
     description: {
-        ko: "프로젝트를 시작 후에는 일부 정보가 참여자에게 즉시 노출될 수 있으니, 설정을 다시 한 번 확인해주세요. 공개 여부를 변경하고 싶으실 경우, 공론 관리 페이지 또는 해당 프로젝트 상세 페이지에서 수정하실 수 있습니다.",
-        en: "After you start the project, some information may be immediately exposed to participants, so please check the settings again. If you want to change whether it is public or not, you can edit it on the public management page or the project details page."
+        ko: "‘설문 시작하기’를 선택하시면 설문이 시작되며, 참여자가 응답할 수 있게 됩니다. 진행하시겠습니까?",
+        en: "When you select ‘Start Survey’, the survey will begin and participants will be able to respond. Would you like to proceed?"
     }
 
     start: {
-        ko: "시작하기",
-        en: "Start"
+        ko: "설문 시작하기",
+        en: "Start Survey"
     }
     cancel: {
         ko: "취소",

--- a/packages/main-ui/src/pages/surveys/controller.rs
+++ b/packages/main-ui/src/pages/surveys/controller.rs
@@ -10,10 +10,12 @@ use models::{
 use crate::pages::surveys::components::setting_reward_modal::{
     SettingRewardModal, SettingRewardModalTranslate,
 };
+use crate::pages::surveys::components::start_project_modal::StartProjectModal;
 use crate::pages::surveys::page::{ErrorModal, RemoveSurveyModal};
 use crate::service::login_service::LoginService;
 use crate::service::popup_service::PopupService;
 
+use super::components::start_project_modal::StartProjectModalTranslate;
 use super::i18n::{ErrorModalTranslate, SurveyTranslate};
 
 #[derive(Debug, Clone, Copy)]
@@ -124,6 +126,28 @@ impl Controller {
 
     pub fn get_surveys(&self) -> Option<QueryResponse<SurveyV2Summary>> {
         self.surveys.with(|v| v.clone())
+    }
+
+    pub async fn open_start_survey_popup(&mut self, lang: Language, survey_id: i64) {
+        let tr: StartProjectModalTranslate = translate(&lang);
+        let mut popup_service = self.popup_service;
+        let mut ctrl = self.clone();
+
+        popup_service
+            .open(rsx! {
+                StartProjectModal {
+                    lang,
+                    onsend: move |_| async move {
+                        ctrl.start_survey(survey_id).await;
+                        popup_service.close();
+                    },
+                    oncancel: move |_| {
+                        popup_service.close();
+                    },
+                }
+            })
+            .with_id("start project")
+            .with_title(tr.title);
     }
 
     pub async fn start_survey(&mut self, survey_id: i64) {

--- a/packages/main-ui/src/pages/surveys/new/controller.rs
+++ b/packages/main-ui/src/pages/surveys/new/controller.rs
@@ -1,16 +1,13 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
-use crate::pages::surveys::components::start_project_modal::{
-    StartProjectModal, StartProjectModalTranslate,
-};
 use crate::pages::surveys::models::attribute_combination::AttributeCombination;
 use crate::pages::surveys::models::attribute_group_info::AttributeGroupInfo;
 use bdk::prelude::btracing;
 use by_macros::DioxusController;
 use dioxus::prelude::*;
 use dioxus_logger::tracing;
-use dioxus_translate::{translate, Language};
+use dioxus_translate::translate;
 use models::attribute_v2::AgeV2;
 use models::response::AgeV3;
 use models::{
@@ -20,8 +17,7 @@ use models::{
 use models::{AttributeDistribute, AttributeQuota};
 
 use crate::{
-    pages::surveys::models::current_step::CurrentStep,
-    service::{login_service::LoginService, popup_service::PopupService},
+    pages::surveys::models::current_step::CurrentStep, service::login_service::LoginService,
 };
 
 use super::{
@@ -39,7 +35,6 @@ pub struct Controller {
 
     survey_request: Signal<Option<CreateSurveyResponse>>,
 
-    popup_service: PopupService,
     panels: Signal<Vec<PanelV2Summary>>,
     selected_panels: Signal<Vec<PanelV2>>,
     maximum_panel_count: Signal<Vec<u64>>,
@@ -139,8 +134,6 @@ impl Controller {
 
             current_step: use_signal(|| CurrentStep::CreateSurvey),
             panels: use_signal(|| vec![]),
-
-            popup_service: use_context(),
 
             selected_panels: use_signal(|| vec![]),
             maximum_panel_count: use_signal(|| vec![]),
@@ -587,10 +580,8 @@ impl Controller {
         self.total_panel_members.set(0);
     }
 
-    pub async fn open_start_project_modal(&mut self, lang: Language) {
-        let tr: StartProjectModalTranslate = translate(&lang);
+    pub async fn clicked_start_project(&mut self) {
         let ctrl = self.clone();
-        let mut popup_service = self.popup_service;
 
         let combi = self.attribute_combinations();
         let totals = self.total_counts();
@@ -617,36 +608,18 @@ impl Controller {
 
         let survey_id = self.survey_id();
 
-        popup_service
-            .open(rsx! {
-                StartProjectModal {
-                    lang,
-                    onsend: {
-                        move |_| {
-                            let survey_request = survey_request.clone();
-                            async move {
-                                if survey_id.is_none() {
-                                    ctrl.create_survey(org_id, survey_request, total_panels).await;
-                                } else {
-                                    ctrl.update_survey(
-                                            survey_id.unwrap_or_default(),
-                                            org_id,
-                                            survey_request,
-                                            total_panels,
-                                        )
-                                        .await;
-                                }
-                                popup_service.close();
-                            }
-                        }
-                    },
-                    oncancel: move |_| {
-                        popup_service.close();
-                    },
-                }
-            })
-            .with_id("start project")
-            .with_title(tr.title);
+        if survey_id.is_none() {
+            ctrl.create_survey(org_id, survey_request, total_panels)
+                .await;
+        } else {
+            ctrl.update_survey(
+                survey_id.unwrap_or_default(),
+                org_id,
+                survey_request,
+                total_panels,
+            )
+            .await;
+        }
     }
 
     pub async fn update_survey(

--- a/packages/main-ui/src/pages/surveys/new/page.rs
+++ b/packages/main-ui/src/pages/surveys/new/page.rs
@@ -62,7 +62,7 @@ pub fn SurveyCreatePage(lang: Language, survey_id: Option<i64>) -> Element {
                     combination_error: ctrl.combination_error(),
 
                     clicked_complete_button: move |_| async move {
-                        ctrl.open_start_project_modal(lang).await;
+                        ctrl.clicked_start_project().await;
                     },
 
                     change_selected_tab: move |selected: bool| {

--- a/packages/main-ui/src/pages/surveys/page.rs
+++ b/packages/main-ui/src/pages/surveys/page.rs
@@ -192,7 +192,7 @@ pub fn SurveyPage(props: SurveyProps) -> Element {
                                                         onclick: {
                                                             let id = survey.id.clone();
                                                             move |_| async move {
-                                                                ctrl.start_survey(id).await;
+                                                                ctrl.open_start_survey_popup(props.lang, id).await;
                                                             }
                                                         },
                                                         div { class: "text-hover font-semibold text-sm", "{translate.start_survey_create}" }


### PR DESCRIPTION
survey modal 워딩, 위치 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a confirmation popup when starting a survey from the survey list, providing instructions and requiring user confirmation before proceeding.

- **Improvements**
  - Updated the modal's title, description, and button labels for starting a survey to offer clearer instructions in both English and Korean.
  - Streamlined the survey creation and update flow by removing the confirmation popup from the new survey setup page, allowing immediate progression after validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->