### PR TITLE
Feature/members

### DIFF
--- a/packages/api/src/controllers/v2/contents/mod.rs
+++ b/packages/api/src/controllers/v2/contents/mod.rs
@@ -2,20 +2,13 @@ use by_axum::{
     aide,
     auth::Authorization,
     axum::{
-        extract::{Path, Query, State},
+        extract::{Path, State},
         routing::get,
         Extension, Json,
     },
 };
 
-use models::{
-    discussion_participants::DiscussionParticipant,
-    dto::{
-        ParticipantData, ParticipantDataGetResponse, ParticipantDataParam,
-        ParticipantDataReadActionType,
-    },
-    *,
-};
+use models::{discussion_participants::DiscussionParticipant, dto::ParticipantData, *};
 
 use crate::utils::app_claims::AppClaims;
 
@@ -84,22 +77,12 @@ impl ContentController {
         State(ctrl): State<ContentController>,
         Extension(auth): Extension<Option<Authorization>>,
         Path(ContentPath { content_id }): Path<ContentPath>,
-        Query(q): Query<ParticipantDataParam>,
-    ) -> Result<Json<ParticipantDataGetResponse>> {
+    ) -> Result<Json<ParticipantData>> {
         let _ = match auth {
             Some(Authorization::Bearer { ref claims }) => AppClaims(claims).get_user_id(),
             _ => return Err(ApiError::Unauthorized),
         };
 
-        match q {
-            ParticipantDataParam::Read(param)
-                if param.action == Some(ParticipantDataReadActionType::Find) =>
-            {
-                Ok(Json(ParticipantDataGetResponse::Read(
-                    ctrl.query(content_id).await?,
-                )))
-            }
-            _ => Err(ApiError::InvalidAction),
-        }
+        Ok(Json(ctrl.query(content_id).await?))
     }
 }

--- a/packages/api/src/controllers/v2/contents/mod.rs
+++ b/packages/api/src/controllers/v2/contents/mod.rs
@@ -1,0 +1,105 @@
+use by_axum::{
+    aide,
+    auth::Authorization,
+    axum::{
+        extract::{Path, Query, State},
+        routing::get,
+        Extension, Json,
+    },
+};
+
+use models::{
+    discussion_participants::DiscussionParticipant,
+    dto::{
+        ParticipantData, ParticipantDataGetResponse, ParticipantDataParam,
+        ParticipantDataReadActionType,
+    },
+    *,
+};
+
+use crate::utils::app_claims::AppClaims;
+
+#[derive(Clone, Debug)]
+pub struct ContentController {
+    #[allow(dead_code)]
+    pool: sqlx::Pool<sqlx::Postgres>,
+}
+
+#[derive(
+    Debug, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema, aide::OperationIo,
+)]
+#[serde(rename_all = "kebab-case")]
+pub struct ContentPath {
+    pub content_id: i64,
+}
+
+impl ContentController {
+    async fn query(&self, content_id: i64) -> Result<ParticipantData> {
+        let mut tx = self.pool.begin().await?;
+
+        let participants = DiscussionParticipant::query_builder()
+            .discussion_id_equals(content_id)
+            .query()
+            .map(DiscussionParticipant::from)
+            .fetch_all(&mut *tx)
+            .await?;
+
+        let mut users = vec![];
+
+        for participant in participants.clone() {
+            let id = participant.user_id;
+
+            let u = User::query_builder()
+                .id_equals(id)
+                .query()
+                .map(UserSummary::from)
+                .fetch_one(&mut *tx)
+                .await?;
+
+            users.push(u);
+        }
+
+        tx.commit().await?;
+
+        Ok(ParticipantData {
+            content_id,
+            participants,
+            users,
+        })
+    }
+}
+
+impl ContentController {
+    pub fn new(pool: sqlx::Pool<sqlx::Postgres>) -> Self {
+        Self { pool }
+    }
+
+    pub fn route(&self) -> Result<by_axum::axum::Router> {
+        Ok(by_axum::axum::Router::new()
+            .route("/:content-id", get(Self::get_contents))
+            .with_state(self.clone()))
+    }
+
+    pub async fn get_contents(
+        State(ctrl): State<ContentController>,
+        Extension(auth): Extension<Option<Authorization>>,
+        Path(ContentPath { content_id }): Path<ContentPath>,
+        Query(q): Query<ParticipantDataParam>,
+    ) -> Result<Json<ParticipantDataGetResponse>> {
+        let _ = match auth {
+            Some(Authorization::Bearer { ref claims }) => AppClaims(claims).get_user_id(),
+            _ => return Err(ApiError::Unauthorized),
+        };
+
+        match q {
+            ParticipantDataParam::Read(param)
+                if param.action == Some(ParticipantDataReadActionType::Find) =>
+            {
+                Ok(Json(ParticipantDataGetResponse::Read(
+                    ctrl.query(content_id).await?,
+                )))
+            }
+            _ => Err(ApiError::InvalidAction),
+        }
+    }
+}

--- a/packages/api/src/controllers/v2/deliberations/_id/discussions.rs
+++ b/packages/api/src/controllers/v2/deliberations/_id/discussions.rs
@@ -393,7 +393,6 @@ impl DiscussionController {
                 maximum_count,
                 None,
                 "".to_string(),
-                vec![],
             )
             .await?
             .ok_or(ApiError::DeliberationNotFound)?;

--- a/packages/api/src/controllers/v2/deliberations/_id/discussions.rs
+++ b/packages/api/src/controllers/v2/deliberations/_id/discussions.rs
@@ -338,14 +338,8 @@ impl DiscussionController {
             .update(
                 id,
                 DiscussionRepositoryUpdateRequest {
-                    deliberation_id: None,
-                    started_at: None,
-                    ended_at: None,
-                    name: None,
-                    description: None,
                     meeting_id: Some(meeting.meeting_id.unwrap_or_default()),
-                    pipeline_id: None,
-                    maximum_count: None,
+                    ..Default::default()
                 },
             )
             .await
@@ -399,6 +393,7 @@ impl DiscussionController {
                 maximum_count,
                 None,
                 "".to_string(),
+                vec![],
             )
             .await?
             .ok_or(ApiError::DeliberationNotFound)?;

--- a/packages/api/src/controllers/v2/mod.rs
+++ b/packages/api/src/controllers/v2/mod.rs
@@ -1,4 +1,5 @@
 pub mod comments;
+pub mod contents;
 pub mod inquiries;
 pub mod landing;
 pub mod metadata;
@@ -49,6 +50,10 @@ impl Version2Controller {
             .nest(
                 "/profile",
                 profile::ProfileController::new(pool.clone()).route()?,
+            )
+            .nest(
+                "/contents",
+                contents::ContentController::new(pool.clone()).route()?,
             )
             .nest(
                 "/projects",

--- a/packages/api/src/controllers/v2/organizations/_id/deliberations.rs
+++ b/packages/api/src/controllers/v2/organizations/_id/deliberations.rs
@@ -1239,7 +1239,6 @@ impl DeliberationController {
                         disc.maximum_count,
                         None,
                         "".to_string(),
-                        vec![],
                     )
                     .await?
                     .ok_or(ApiError::DeliberationDiscussionException)?;
@@ -1443,7 +1442,6 @@ impl DeliberationController {
                         disc.maximum_count,
                         None,
                         "".to_string(),
-                        vec![],
                     )
                     .await?
                     .ok_or(ApiError::DeliberationDiscussionException)?;

--- a/packages/api/src/controllers/v2/organizations/_id/deliberations.rs
+++ b/packages/api/src/controllers/v2/organizations/_id/deliberations.rs
@@ -1239,6 +1239,7 @@ impl DeliberationController {
                         disc.maximum_count,
                         None,
                         "".to_string(),
+                        vec![],
                     )
                     .await?
                     .ok_or(ApiError::DeliberationDiscussionException)?;
@@ -1442,6 +1443,7 @@ impl DeliberationController {
                         disc.maximum_count,
                         None,
                         "".to_string(),
+                        vec![],
                     )
                     .await?
                     .ok_or(ApiError::DeliberationDiscussionException)?;

--- a/packages/api/src/main.rs
+++ b/packages/api/src/main.rs
@@ -19,6 +19,7 @@ use models::{
     deliberation_response::DeliberationResponse, deliberation_role::DeliberationRole,
     deliberation_sample_survey_roles::deliberation_sample_survey_role::DeliberationSampleSurveyRole,
     deliberation_user::DeliberationUser, deliberation_vote::DeliberationVote,
+    discussion_conversations::discussion_conversation::DiscussionConversation,
     discussion_participants::DiscussionParticipant, invitation::Invitation,
     response::SurveyResponse, review::Review, v2::Institution,
 };
@@ -145,6 +146,7 @@ async fn migration(pool: &sqlx::Pool<sqlx::Postgres>) -> Result<()> {
         DeliberationVote,
         Step,
         Discussion,
+        DiscussionConversation,
         DiscussionParticipant,
         DeliberationResource,
         DeliberationComment,

--- a/packages/api/src/utils/aws_chime_sdk_meeting.rs
+++ b/packages/api/src/utils/aws_chime_sdk_meeting.rs
@@ -105,6 +105,9 @@ impl ChimeMeetingService {
         meeting: &MeetingInfo,
         external_user_id: &str,
     ) -> Result<AttendeeInfo, ApiError> {
+        let user_id = format!("u-{:?}", external_user_id);
+        let external_user_id = user_id.as_str();
+
         let resp = match self
             .client
             .create_attendee()

--- a/packages/models/src/discussion_conversations/discussion_conversation.rs
+++ b/packages/models/src/discussion_conversations/discussion_conversation.rs
@@ -1,0 +1,18 @@
+use bdk::prelude::*;
+
+#[api_model(base = "/", table = discussion_conversations)]
+pub struct DiscussionConversation {
+    #[api_model(summary, primary_key)]
+    pub id: i64,
+    #[api_model(summary, auto = [insert])]
+    pub created_at: i64,
+    #[api_model(summary, auto = [insert, update])]
+    pub updated_at: i64,
+
+    #[api_model(summary, many_to_one = discussions)]
+    pub discussion_id: i64,
+    #[api_model(summary)]
+    pub user_id: i64,
+    #[api_model(summary, create)]
+    pub comment: String,
+}

--- a/packages/models/src/discussion_conversations/mod.rs
+++ b/packages/models/src/discussion_conversations/mod.rs
@@ -1,0 +1,1 @@
+pub mod discussion_conversation;

--- a/packages/models/src/discussions/discussion.rs
+++ b/packages/models/src/discussions/discussion.rs
@@ -1,6 +1,7 @@
 use bdk::prelude::*;
 use validator::Validate;
 
+use crate::discussion_conversations::discussion_conversation::DiscussionConversation;
 use crate::discussion_participants::DiscussionParticipant;
 
 use crate::{ResourceFile, User};
@@ -44,8 +45,9 @@ pub struct Discussion {
     #[api_model(summary, action_by_id = update, version = v0.4)]
     pub pipeline_id: String,
 
-    #[api_model(summary, type = JSONB, version = v0.5)]
-    pub comments: Vec<DiscussionComment>,
+    #[api_model(summary, one_to_many = discussion_conversations, foreign_key = discussion_id)]
+    #[serde(default)]
+    pub conversations: Vec<DiscussionConversation>,
 
     #[api_model(summary, one_to_many = discussion_participants, foreign_key = discussion_id)]
     #[serde(default)]

--- a/packages/models/src/discussions/discussion.rs
+++ b/packages/models/src/discussions/discussion.rs
@@ -44,6 +44,9 @@ pub struct Discussion {
     #[api_model(summary, action_by_id = update, version = v0.4)]
     pub pipeline_id: String,
 
+    #[api_model(summary, type = JSONB, version = v0.5)]
+    pub comments: Vec<DiscussionComment>,
+
     #[api_model(summary, one_to_many = discussion_participants, foreign_key = discussion_id)]
     #[serde(default)]
     pub participants: Vec<DiscussionParticipant>,
@@ -69,4 +72,12 @@ impl Into<DiscussionCreateRequest> for Discussion {
             maximum_count: self.maximum_count,
         }
     }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "server", derive(schemars::JsonSchema, aide::OperationIo))]
+pub struct DiscussionComment {
+    created_at: i64,
+    user_id: i64,
+    comment: String,
 }

--- a/packages/models/src/dto/v2/mod.rs
+++ b/packages/models/src/dto/v2/mod.rs
@@ -1,7 +1,9 @@
 pub mod landing;
 pub mod meeting;
+pub mod participant;
 pub mod profile;
 
 pub use landing::*;
 pub use meeting::*;
+pub use participant::*;
 pub use profile::*;

--- a/packages/models/src/dto/v2/participant.rs
+++ b/packages/models/src/dto/v2/participant.rs
@@ -1,0 +1,10 @@
+use bdk::prelude::*;
+
+use crate::{discussion_participants::DiscussionParticipant, UserSummary};
+
+#[api_model(base = "/v2/contents/:content-id", database = skip, read_action = find)]
+pub struct ParticipantData {
+    pub content_id: i64,
+    pub participants: Vec<DiscussionParticipant>,
+    pub users: Vec<UserSummary>,
+}

--- a/packages/models/src/dto/v2/participant.rs
+++ b/packages/models/src/dto/v2/participant.rs
@@ -2,7 +2,7 @@ use bdk::prelude::*;
 
 use crate::{discussion_participants::DiscussionParticipant, UserSummary};
 
-#[api_model(base = "/v2/contents/:content-id", database = skip, read_action = find)]
+#[api_model(base = "/v2/contents", database = skip)]
 pub struct ParticipantData {
     pub content_id: i64,
     pub participants: Vec<DiscussionParticipant>,

--- a/packages/models/src/lib.rs
+++ b/packages/models/src/lib.rs
@@ -64,6 +64,7 @@ pub mod deliberation_surveys;
 pub mod deliberation_users;
 pub mod deliberation_votes;
 pub mod deliberations;
+pub mod discussion_conversations;
 pub mod discussion_groups;
 pub mod discussion_participants;
 pub mod discussion_resources;

--- a/packages/user-ui/src/components/icons/mod.rs
+++ b/packages/user-ui/src/components/icons/mod.rs
@@ -10,6 +10,7 @@ pub mod logo;
 pub mod pencil;
 pub mod person;
 pub mod project;
+pub mod refresh;
 pub mod right_arrow;
 pub mod search;
 pub mod triangle;

--- a/packages/user-ui/src/components/icons/refresh.rs
+++ b/packages/user-ui/src/components/icons/refresh.rs
@@ -1,0 +1,27 @@
+use bdk::prelude::*;
+
+#[component]
+pub fn Refresh(
+    #[props(default = "".to_string())] class: String,
+    #[props(default = "none".to_string())] fill: String,
+    #[props(default = "24".to_string())] width: String,
+    #[props(default = "24".to_string())] height: String,
+) -> Element {
+    rsx! {
+        svg {
+            class,
+            fill,
+            height,
+            id: "Capa_1",
+            "space": "preserve",
+            version: "1.1",
+            view_box: "0 0 489.645 489.645",
+            width,
+            "xlink": "http://www.w3.org/1999/xlink",
+            xmlns: "http://www.w3.org/2000/svg",
+            g {
+                path { d: "M460.656,132.911c-58.7-122.1-212.2-166.5-331.8-104.1c-9.4,5.2-13.5,16.6-8.3,27c5.2,9.4,16.6,13.5,27,8.3\r\n\t\tc99.9-52,227.4-14.9,276.7,86.3c65.4,134.3-19,236.7-87.4,274.6c-93.1,51.7-211.2,17.4-267.6-70.7l69.3,14.5\r\n\t\tc10.4,2.1,21.8-4.2,23.9-15.6c2.1-10.4-4.2-21.8-15.6-23.9l-122.8-25c-20.6-2-25,16.6-23.9,22.9l15.6,123.8\r\n\t\tc1,10.4,9.4,17.7,19.8,17.7c12.8,0,20.8-12.5,19.8-23.9l-6-50.5c57.4,70.8,170.3,131.2,307.4,68.2\r\n\t\tC414.856,432.511,548.256,314.811,460.656,132.911z" }
+            }
+        }
+    }
+}

--- a/packages/user-ui/src/pages/projects/_id/discussion/_id/components/participant_sidebar.rs
+++ b/packages/user-ui/src/pages/projects/_id/discussion/_id/components/participant_sidebar.rs
@@ -1,5 +1,6 @@
 use bdk::prelude::*;
 use by_components::icons::validations::Clear;
+use models::{discussion_participants::DiscussionParticipant, UserSummary};
 
 use crate::components::icons::Logo;
 
@@ -7,7 +8,8 @@ use crate::components::icons::Logo;
 pub fn ParticipantSidebar(
     show_member: bool,
     hide_member: EventHandler<MouseEvent>,
-    emails: Vec<String>,
+    participants: Vec<DiscussionParticipant>,
+    users: Vec<UserSummary>,
 ) -> Element {
     rsx! {
         div {
@@ -32,7 +34,7 @@ pub fn ParticipantSidebar(
                     }
                 }
                 div { class: "flex flex-col w-full h-lvh justify-start items-start px-10 py-20 bg-key-gray gap-20",
-                    for email in emails {
+                    for user in users {
                         div { class: "flex flex-row w-full justify-start items-center gap-4",
                             div { class: "flex flex-row w-30 h-30 justify-center items-center rounded-full bg-text-gray",
                                 Logo {
@@ -42,7 +44,7 @@ pub fn ParticipantSidebar(
                                 }
                             }
 
-                            div { class: "font-medium text-white text-sm/18", {email} }
+                            div { class: "font-medium text-white text-sm/18", {user.email} }
                         }
                     }
                 }

--- a/packages/user-ui/src/pages/projects/_id/discussion/_id/components/participant_sidebar.rs
+++ b/packages/user-ui/src/pages/projects/_id/discussion/_id/components/participant_sidebar.rs
@@ -7,12 +7,12 @@ use crate::components::icons::{refresh::Refresh, Logo};
 #[component]
 pub fn ParticipantSidebar(
     show_member: bool,
-    hide_member: EventHandler<MouseEvent>,
-
-    refresh: EventHandler<MouseEvent>,
-
     participants: Vec<DiscussionParticipant>,
     users: Vec<UserSummary>,
+
+    hide_member: EventHandler<MouseEvent>,
+    refresh: EventHandler<MouseEvent>,
+    clicked_attendee: EventHandler<String>,
 ) -> Element {
     rsx! {
         div {
@@ -48,8 +48,15 @@ pub fn ParticipantSidebar(
                     }
                 }
                 div { class: "flex flex-col w-full h-lvh justify-start items-start px-10 py-20 bg-key-gray gap-20",
-                    for user in users {
-                        div { class: "flex flex-row w-full justify-start items-center gap-4",
+                    for (i , user) in users.iter().enumerate() {
+                        button {
+                            class: "flex flex-row w-full justify-start items-center gap-4",
+                            onclick: {
+                                let participant_id = participants[i].participant_id.clone();
+                                move |_| {
+                                    clicked_attendee.call(participant_id.clone());
+                                }
+                            },
                             div { class: "flex flex-row w-30 h-30 justify-center items-center rounded-full bg-text-gray",
                                 Logo {
                                     width: "21",
@@ -58,7 +65,7 @@ pub fn ParticipantSidebar(
                                 }
                             }
 
-                            div { class: "font-medium text-white text-sm/18", {user.email} }
+                            div { class: "font-medium text-white text-sm/18", {user.email.clone()} }
                         }
                     }
                 }

--- a/packages/user-ui/src/pages/projects/_id/discussion/_id/components/participant_sidebar.rs
+++ b/packages/user-ui/src/pages/projects/_id/discussion/_id/components/participant_sidebar.rs
@@ -11,8 +11,8 @@ pub fn ParticipantSidebar(
     users: Vec<UserSummary>,
 
     hide_member: EventHandler<MouseEvent>,
-    refresh: EventHandler<MouseEvent>,
-    clicked_attendee: EventHandler<String>,
+    onrefresh: EventHandler<MouseEvent>,
+    onselect: EventHandler<String>,
 ) -> Element {
     rsx! {
         div {
@@ -25,7 +25,7 @@ pub fn ParticipantSidebar(
                         div { class: "font-semibold text-white text-sm/17", "Participants" }
                         button {
                             onclick: move |e: Event<MouseData>| {
-                                refresh.call(e);
+                                onrefresh.call(e);
                             },
                             Refresh {
                                 width: "12",
@@ -54,7 +54,7 @@ pub fn ParticipantSidebar(
                             onclick: {
                                 let participant_id = participants[i].participant_id.clone();
                                 move |_| {
-                                    clicked_attendee.call(participant_id.clone());
+                                    onselect.call(participant_id.clone());
                                 }
                             },
                             div { class: "flex flex-row w-30 h-30 justify-center items-center rounded-full bg-text-gray",

--- a/packages/user-ui/src/pages/projects/_id/discussion/_id/components/participant_sidebar.rs
+++ b/packages/user-ui/src/pages/projects/_id/discussion/_id/components/participant_sidebar.rs
@@ -2,12 +2,15 @@ use bdk::prelude::*;
 use by_components::icons::validations::Clear;
 use models::{discussion_participants::DiscussionParticipant, UserSummary};
 
-use crate::components::icons::Logo;
+use crate::components::icons::{refresh::Refresh, Logo};
 
 #[component]
 pub fn ParticipantSidebar(
     show_member: bool,
     hide_member: EventHandler<MouseEvent>,
+
+    refresh: EventHandler<MouseEvent>,
+
     participants: Vec<DiscussionParticipant>,
     users: Vec<UserSummary>,
 ) -> Element {
@@ -20,6 +23,17 @@ pub fn ParticipantSidebar(
                     div { class: "flex flex-row w-fit justify-start items-center gap-10",
                         Logo { width: "30", height: "20", class: "fill-third" }
                         div { class: "font-semibold text-white text-sm/17", "Participants" }
+                        button {
+                            onclick: move |e: Event<MouseData>| {
+                                refresh.call(e);
+                            },
+                            Refresh {
+                                width: "12",
+                                height: "12",
+                                fill: "#bfc8d9",
+                                class: "[&>path]:stroke-discussion-border-gray",
+                            }
+                        }
                     }
                     button {
                         onclick: move |e: Event<MouseData>| {

--- a/packages/user-ui/src/pages/projects/_id/discussion/_id/controller.rs
+++ b/packages/user-ui/src/pages/projects/_id/discussion/_id/controller.rs
@@ -31,7 +31,7 @@ impl Controller {
     ) -> std::result::Result<Self, RenderError> {
         let participants = use_server_future(move || async move {
             ParticipantData::get_client(&crate::config::get().api_url)
-                .find(discussion_id())
+                .get(discussion_id())
                 .await
                 .unwrap_or_default()
         })?;
@@ -55,12 +55,12 @@ impl Controller {
         Ok(ctrl)
     }
 
-    pub fn refresh(&mut self) {
+    pub fn handle_refresh(&mut self) {
         self.participants.restart();
     }
 
     // NOTE: this function is not testing because multiple user testing is restricted.
-    pub fn clicked_attendee(&mut self, attendee_id: String) {
+    pub fn handle_selecting_attendee(&mut self, attendee_id: String) {
         let _ = eval(&format!(r#"window._focusVideo("{attendee_id}");"#)).unwrap();
     }
 

--- a/packages/user-ui/src/pages/projects/_id/discussion/_id/page.rs
+++ b/packages/user-ui/src/pages/projects/_id/discussion/_id/page.rs
@@ -15,6 +15,8 @@ pub fn DiscussionVideoPage(
     let mut mic = use_signal(|| true);
     let mut video = use_signal(|| true);
 
+    let participants = ctrl.participants()?;
+
     rsx! {
         div { class: "relative flex flex-col w-full h-lvh justify-start items-start",
             Header {
@@ -53,13 +55,8 @@ pub fn DiscussionVideoPage(
                     hide_member: move |_| {
                         show_side_member.set(false);
                     },
-                    emails: vec![
-                        "aaa@bbb.ccc".to_string(),
-                        "aaa1@bbb.ccc".to_string(),
-                        "aaa2@bbb.ccc".to_string(),
-                        "aaa3@bbb.ccc".to_string(),
-                        "aaa4@bbb.ccc".to_string(),
-                    ],
+                    participants: participants.participants,
+                    users: participants.users,
                 }
             }
         }

--- a/packages/user-ui/src/pages/projects/_id/discussion/_id/page.rs
+++ b/packages/user-ui/src/pages/projects/_id/discussion/_id/page.rs
@@ -57,6 +57,10 @@ pub fn DiscussionVideoPage(
                     refresh: move |_| {
                         ctrl.refresh();
                     },
+
+                    clicked_attendee: move |attendee_id: String| {
+                        ctrl.clicked_attendee(attendee_id);
+                    },
                     participants: participants.participants,
                     users: participants.users,
                 }

--- a/packages/user-ui/src/pages/projects/_id/discussion/_id/page.rs
+++ b/packages/user-ui/src/pages/projects/_id/discussion/_id/page.rs
@@ -11,7 +11,7 @@ pub fn DiscussionVideoPage(
     discussion_id: ReadOnlySignal<i64>,
 ) -> Element {
     let mut show_side_member = use_signal(|| false);
-    let ctrl = Controller::init(lang, project_id, discussion_id)?;
+    let mut ctrl = Controller::init(lang, project_id, discussion_id)?;
     let mut mic = use_signal(|| true);
     let mut video = use_signal(|| true);
 
@@ -49,11 +49,13 @@ pub fn DiscussionVideoPage(
                     }
                 }
 
-                //FIXME: fix to real email
                 ParticipantSidebar {
                     show_member: show_side_member(),
                     hide_member: move |_| {
                         show_side_member.set(false);
+                    },
+                    refresh: move |_| {
+                        ctrl.refresh();
                     },
                     participants: participants.participants,
                     users: participants.users,

--- a/packages/user-ui/src/pages/projects/_id/discussion/_id/page.rs
+++ b/packages/user-ui/src/pages/projects/_id/discussion/_id/page.rs
@@ -54,12 +54,12 @@ pub fn DiscussionVideoPage(
                     hide_member: move |_| {
                         show_side_member.set(false);
                     },
-                    refresh: move |_| {
-                        ctrl.refresh();
+                    onrefresh: move |_| {
+                        ctrl.handle_refresh();
                     },
 
-                    clicked_attendee: move |attendee_id: String| {
-                        ctrl.clicked_attendee(attendee_id);
+                    onselect: move |attendee_id: String| {
+                        ctrl.handle_selecting_attendee(attendee_id);
                     },
                     participants: participants.participants,
                     users: participants.users,


### PR DESCRIPTION
- zoom 화면 내 members 리스트 api 연동
- 멤버에서 email 클릭시 해당 email의 zoom 화면이 뜨도록 로직 추가(multi user에 대한 테스팅은 로컬에서 제한이 되어 해당 부분에 대한 테스팅 필요)
- comment field 추가 (추후 discussion 내 comment ui로 사용될 예정)

comment field 추가 후 정상 동작하는지 확인이 필요해 don't merge label 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a refreshable participant sidebar in discussion video pages, allowing users to view, select, and focus on discussion participants.
  - Introduced a refresh icon for UI consistency and interaction.
  - Users can now focus on a specific attendee's video during discussions.

- **Improvements**
  - Participant data in the sidebar now includes detailed user information, replacing static email lists with interactive participant selection.
  - Enhanced meeting session cleanup and error handling for a smoother user experience.

- **Backend Enhancements**
  - New API endpoint to fetch discussion participants and associated user summaries.
  - Extended data models to support discussion conversations and participant data retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->